### PR TITLE
Add explicite yum usage to never mock

### DIFF
--- a/1.20/el7/mock/mate1.20-7-x86_64.cfg
+++ b/1.20/el7/mock/mate1.20-7-x86_64.cfg
@@ -5,8 +5,11 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils f
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 
+config_opts['package_manager'] = 'yum'
+config_opts['plugin_conf']['yum_cache_enable'] = False
 config_opts['yum.conf'] = """
 [main]
+cachedir=/var/cache/yum
 keepcache=1
 debuglevel=2
 reposdir=/dev/null


### PR DESCRIPTION
Hi,

You need to specify that yum should be used on Centos 7.9, mock version 2.12-1, instead of dnf. With this modification, the binaries rpms build will be successed.

I tried it, and workes for me :)

--
Fonya